### PR TITLE
associate State variable with Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -25,7 +25,7 @@ type Client struct {
 	codec      Codec
 	handlers   map[string]*handler
 	disconnect chan struct{}
-	state      interface{} // additional information to associate with client
+	State      *State // additional information to associate with client
 }
 
 // NewClient returns a new Client to handle requests to the
@@ -328,13 +328,4 @@ func (c *Client) Notify(method string, args interface{}) error {
 	c.request.Seq = 0
 	c.request.Method = method
 	return c.codec.WriteRequest(&c.request, args)
-}
-
-// State returns the state associated with the client. It is useful for storing
-// any additional information that might be relevant to the request from the
-// client or for storing information that must persist across RPC calls, like
-// authentication. This can be assigned while serving the client using
-// ServeCodecWithState.
-func (c *Client) State() interface{} {
-	return c.state
 }

--- a/server.go
+++ b/server.go
@@ -158,20 +158,20 @@ func (s *Server) ServeConn(conn io.ReadWriteCloser) {
 // ServeCodec is like ServeConn but uses the specified codec to
 // decode requests and encode responses.
 func (s *Server) ServeCodec(codec Codec) {
-	s.ServeCodecWithState(codec, nil)
+	s.ServeCodecWithState(codec, NewState())
 }
 
 // ServeCodec is like ServeCodec but also gives the ability to
 // associate a state variable with the client that persists
 // across RPC calls.
-func (s *Server) ServeCodecWithState(codec Codec, state interface{}) {
+func (s *Server) ServeCodecWithState(codec Codec, state *State) {
 	defer codec.Close()
 
 	// Client also handles the incoming connections.
 	c := NewClientWithCodec(codec)
 	c.server = true
 	c.handlers = s.handlers
-	c.state = state
+	c.State = state
 
 	s.eventHub.Publish(connectionEvent{c})
 	c.Run()

--- a/state.go
+++ b/state.go
@@ -1,0 +1,25 @@
+package rpc2
+
+import "sync"
+
+type State struct {
+	store map[string]interface{}
+	m     sync.RWMutex
+}
+
+func NewState() *State {
+	return &State{store: make(map[string]interface{})}
+}
+
+func (s *State) Get(key string) (value interface{}, ok bool) {
+	s.m.RLock()
+	value, ok = s.store[key]
+	s.m.RUnlock()
+	return
+}
+
+func (s *State) Set(key string, value interface{}) {
+	s.m.Lock()
+	s.store[key] = value
+	s.m.Unlock()
+}


### PR DESCRIPTION
This commit levels your approach one level higher. Because state can be modified during the connection and handlers run concurrently, functions modifying the state must be synchronized. That's why I made the State a separate type with a RWLock in it.
